### PR TITLE
Update VoyageAI multilingual model

### DIFF
--- a/Model/VoyageAI/models.json
+++ b/Model/VoyageAI/models.json
@@ -24,7 +24,7 @@
             "inputTokenPrice": 0.12,
             "dimensions": 1536
         },
-        "voyage-multilingual": {
+        "voyage-multilingual-2": {
             "description": "Optimized for multilingual retrieval and RAG",
             "inputTokens": 32000,
             "inputTokenPrice": 0.12,


### PR DESCRIPTION
The following error message was being thrown when using VoyageAI with the current ``multilingual``  option:

```
Model voyage-multilingual is not supported. Supported models are ['voyage-large-2-instruct', 'voyage-large-2-instruct-l4', 'voyage-law-2', 'voyage-code-2', 'voyage-02', 'voyage-2', 'voyage-01', 'voyage-lite-01', 'voyage-lite-01-instruct', 'voyage-lite-02-instruct', 'voyage-multilingual-2', 'voyage-large-2'].
```