### PR TITLE
sentence splitting implementation

### DIFF
--- a/Embeddings.php
+++ b/Embeddings.php
@@ -338,17 +338,18 @@ class Embeddings
             if ($slen > $this->getChunkSize()) {
                 // sentence is too long, we need to split it further
                 if ($this->logger instanceof CLI) $this->logger->warning(
-                    'Sentence too long, splitting not implemented yet'
+                    'Sentence too long, splitting it into smaller parts'
                 );
-                continue;
-            }
-
-            if ($chunklen + $slen < $this->getChunkSize()) {
+                // Split the sentence into smaller parts
+                $subSentences = $this->splitLongSentence($sentence, $tiktok);
+                foreach ($subSentences as $subSentence) {
+                    $subSlen = count($tiktok->encode($subSentence));
+                    if ($chunklen + $subSlen < $this->getChunkSize()) {
                 // add to current chunk
-                $chunk .= $sentence;
-                $chunklen += $slen;
+                        $chunk .= $subSentence;
+                        $chunklen += $subSlen;
                 // remember sentence for overlap check
-                $this->rememberSentence($sentence);
+                        $this->rememberSentence($subSentence);
             } else {
                 // add current chunk to result
                 $chunk = trim($chunk);
@@ -356,13 +357,61 @@ class Embeddings
 
                 // start new chunk with remembered sentences
                 $chunk = implode(' ', $this->sentenceQueue);
-                $chunk .= $sentence;
+                        $chunk .= $subSentence;
                 $chunklen = count($tiktok->encode($chunk));
             }
         }
-        $chunks[] = $chunk;
+            } else {
+                if ($chunklen + $slen < $this->getChunkSize()) {
+                    // add to current chunk
+                    $chunk .= $sentence;
+                    $chunklen += $slen;
+                    // remember sentence for overlap check
+                    $this->rememberSentence($sentence);
+                } else {
+                    // add current chunk to result
+                    $chunk = trim($chunk);
+                    if ($chunk !== '') $chunks[] = $chunk;
+
+                    // start new chunk with remembered sentences
+                    $chunk = implode(' ', $this->sentenceQueue);
+                    $chunk .= $sentence;
+                    $chunklen = count($tiktok->encode($chunk));
+                }
+            }
+        }
+        $chunks[] = trim($chunk);
 
         return $chunks;
+    }
+
+    protected function splitLongSentence($sentence, $tiktok)
+    {
+        $words = explode(' ', $sentence);
+        $subSentences = [];
+        $currentSubSentence = '';
+        $currentSubSentenceLen = 0;
+        $chunkSize = $this->getChunkSize();
+
+        foreach ($words as $word) {
+            $wordLen = count($tiktok->encode($word));
+            if ($currentSubSentenceLen + $wordLen < $chunkSize) {
+                $currentSubSentence .= $word . ' ';
+                $currentSubSentenceLen += $wordLen;
+            } else {
+                // add current sub-sentence to result
+                $subSentences[] = trim($currentSubSentence);
+                // start new sub-sentence
+                $currentSubSentence = $word . ' ';
+                $currentSubSentenceLen = $wordLen;
+            }
+        }
+        // add last sub-sentence to result
+        if ($currentSubSentence !== '') {
+            $subSentences[] = trim($currentSubSentence);
+        }
+
+        return $subSentences;
     }
 
     /**


### PR DESCRIPTION
To implement sentence splitting for sentences that are too long, we need to break them down into smaller parts while ensuring that the resulting chunks do not exceed the specified chunk size. Here's an updated version of the splitIntoChunks method that includes sentence splitting for overly long sentences: