### PR TITLE
Update Ollama API embeddings interface for newer version

### DIFF
--- a/Model/Ollama/EmbeddingModel.php
+++ b/Model/Ollama/EmbeddingModel.php
@@ -10,7 +10,7 @@ class EmbeddingModel extends AbstractOllama implements EmbeddingInterface
     public function getEmbedding($text): array
     {
         $data = [
-            'model' => $this->getModelNameWithSuffix(),
+            'model' => $this->getModelName(),
             'input' => $text,
             'options' => [
                 'num_ctx' => $this->getMaxInputTokenLength()
@@ -19,11 +19,4 @@ class EmbeddingModel extends AbstractOllama implements EmbeddingInterface
         $response = $this->request('api/embed', $data);
         return $response['embeddings'][0] ?? [];
     }
-
-    private function getModelNameWithSuffix(): string
-    {
-        $modelName = $this->getModelName();
-        return str_ends_with($modelName, ':latest') ? $modelName : $modelName . ':latest';
-    }
 }
-

--- a/Model/Ollama/EmbeddingModel.php
+++ b/Model/Ollama/EmbeddingModel.php
@@ -10,14 +10,20 @@ class EmbeddingModel extends AbstractOllama implements EmbeddingInterface
     public function getEmbedding($text): array
     {
         $data = [
-            'model' => $this->getModelName(),
-            'prompt' => $text,
+            'model' => $this->getModelNameWithSuffix(),
+            'input' => $text,
             'options' => [
                 'num_ctx' => $this->getMaxInputTokenLength()
             ]
         ];
-        $response = $this->request('embeddings', $data);
+        $response = $this->request('api/embed', $data);
+        return $response['embeddings'][0] ?? [];
+    }
 
-        return $response['embedding'];
+    private function getModelNameWithSuffix(): string
+    {
+        $modelName = $this->getModelName();
+        return str_ends_with($modelName, ':latest') ? $modelName : $modelName . ':latest';
     }
 }
+

--- a/Model/Ollama/models.json
+++ b/Model/Ollama/models.json
@@ -21,13 +21,13 @@
             "outputTokens": 8192,
             "outputTokenPrice": 0
         },
-        "llama3.1:70b": {
-            "description": "Llama 3.1 is a new state-of-the-art model from Meta. 70 billion parameters.",
-            "inputTokens": 8192,
+        "llama3.3:70b": {
+            "description": "New state-of-the-art 70B model from Meta that offers similar performance compared to Llama 3.1 405B model.",
+            "inputTokens": 128000,
             "inputTokenPrice": 0,
             "outputTokens": 8192,
             "outputTokenPrice": 0
-        },
+        }
         "llama3.1:8b": {
             "description": "Llama 3.1 is a new state-of-the-art model from Meta. 8 billion parameters.",
             "inputTokens": 8192,


### PR DESCRIPTION
Following the issue about Ollama #28:

Ollama has had an update to its [API requests](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings).
The endpoint is now "api/embed".  Also, Llama3.3:70b has been published, substituting Llama3.1:70b.